### PR TITLE
Fix for TypeScript and CommonJS projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "json-with-bigint",
   "version": "3.1.1",
   "description": "JS library that allows you to easily serialize and deserialize data with BigInt values",
-  "type": "module",
   "exports": {
     "import": "./json-with-bigint.js",
-    "require": "./json-with-bigint.cjs"
+    "require": "./json-with-bigint.cjs",
+    "types": "./json-with-bigint.d.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #15

The `types` export was definitely missing here.

Removing the `type` field seemed to be the only way to get this to work in a CommonJS/node16 module context. I'm not sure if that has negative impacts on ESM use-cases.