### PR TITLE
Fix for TypeScript CommonJS projects

### DIFF
--- a/json-with-bigint.d.cts
+++ b/json-with-bigint.d.cts
@@ -1,0 +1,28 @@
+type JsonObject = {
+  [x: string]: Json;
+};
+
+type JsonArray = Json[];
+
+export type Json =
+  | null
+  | undefined
+  | string
+  | number
+  | bigint
+  | boolean
+  | JsonObject
+  | {}
+  | JsonArray;
+
+export function JSONStringify(
+  data: Exclude<Json, undefined>,
+  space?: string | number
+): string;
+
+export function JSONStringify(
+  data: undefined,
+  space?: string | number
+): undefined;
+
+export function JSONParse<T extends Json = Json>(serializedData: string): T;


### PR DESCRIPTION
Fixes #15.

Because the loaded file is `.cjs`, TypeScript looks for a `.d.cts`.