### PR TITLE
Use JSON.rawJSON when available

### DIFF
--- a/json-with-bigint.cjs
+++ b/json-with-bigint.cjs
@@ -7,6 +7,16 @@ const noiseValue = /^-?\d+n+$/; // Noise - strings that match the custom format 
 const JSONStringify = (data, space) => {
   if (!data) return JSON.stringify(data);
 
+  if ("rawJSON" in JSON) {
+    return JSON.stringify(
+      data,
+      (_, value) => {
+        return typeof value === "bigint" ? JSON.rawJSON(value.toString()) : value
+      },
+      space
+    );
+  }
+
   const bigInts = /([\[:])?"(-?\d+)n"($|[,\}\]])/g;
   const noise = /([\[:])?("-?\d+n+)n("$|"[,\}\]])/g;
   const convertedToCustomJSON = JSON.stringify(

--- a/json-with-bigint.cjs
+++ b/json-with-bigint.cjs
@@ -5,8 +5,6 @@ const noiseValue = /^-?\d+n+$/; // Noise - strings that match the custom format 
   Converts BigInt values to a custom format (strings with digits and "n" at the end) and then converts them to proper big integers in a JSON string.
 */
 const JSONStringify = (data, space) => {
-  if (!data) return JSON.stringify(data);
-
   if ("rawJSON" in JSON) {
     return JSON.stringify(
       data,
@@ -16,6 +14,8 @@ const JSONStringify = (data, space) => {
       space
     );
   }
+
+  if (!data) return JSON.stringify(data);
 
   const bigInts = /([\[:])?"(-?\d+)n"($|[,\}\]])/g;
   const noise = /([\[:])?("-?\d+n+)n("$|"[,\}\]])/g;

--- a/json-with-bigint.js
+++ b/json-with-bigint.js
@@ -5,8 +5,6 @@ const noiseValue = /^-?\d+n+$/; // Noise - strings that match the custom format 
   Converts BigInt values to a custom format (strings with digits and "n" at the end) and then converts them to proper big integers in a JSON string.
 */
 export const JSONStringify = (data, space) => {
-  if (!data) return JSON.stringify(data);
-
   if ("rawJSON" in JSON) {
     return JSON.stringify(
       data,
@@ -16,6 +14,8 @@ export const JSONStringify = (data, space) => {
       space
     );
   }
+
+  if (!data) return JSON.stringify(data);
 
   const bigInts = /([\[:])?"(-?\d+)n"($|[,\}\]])/g;
   const noise = /([\[:])?("-?\d+n+)n("$|"[,\}\]])/g;

--- a/json-with-bigint.js
+++ b/json-with-bigint.js
@@ -7,6 +7,16 @@ const noiseValue = /^-?\d+n+$/; // Noise - strings that match the custom format 
 export const JSONStringify = (data, space) => {
   if (!data) return JSON.stringify(data);
 
+  if ("rawJSON" in JSON) {
+    return JSON.stringify(
+      data,
+      (_, value) => {
+        return typeof value === "bigint" ? JSON.rawJSON(value.toString()) : value
+      },
+      space
+    );
+  }
+
   const bigInts = /([\[:])?"(-?\d+)n"($|[,\}\]])/g;
   const noise = /([\[:])?("-?\d+n+)n("$|"[,\}\]])/g;
   const convertedToCustomJSON = JSON.stringify(


### PR DESCRIPTION
The proposal for this API is in stage 3 (<https://github.com/tc39/proposal-json-parse-with-source>) and supported by most major browsers and engines, including Nodejs versions 21 and up.

Performance test before:
- One-way: ~925 ms
- Round-trip: ~1130 ms

Performance test after:
- One-way: ~904 ms
- Round-trip: ~1060 ms